### PR TITLE
feat: fixes the 'install from release' test

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -38,7 +38,7 @@ teardown() {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
   echo "# ddev get ddev/ddev-sqlsrv with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get https://github.com/robertoperuzzo/ddev-sqlsrv/archive/refs/heads/main.tar.gz
+  ddev get robertoperuzzo/ddev-sqlsrv
   ddev restart >/dev/null
   # Checks that the sqlsrv drivers for PHP are installed.
   ddev exec "php -i" | grep "sqlsrv"


### PR DESCRIPTION
Replaces the whole repo URL with just `robertoperuzzo/ddev-sqlsrv` in the 'install from release' test.