### PR TITLE
omit_containers db and dba

### DIFF
--- a/config.sqlsrv.yaml
+++ b/config.sqlsrv.yaml
@@ -1,6 +1,7 @@
 #ddev-generated
 
 disable_settings_management: true
+omit_containers: [db,dba]
 
 hooks:
   post-start:


### PR DESCRIPTION
The dba container fails on start with db container broken, so might as well omit both.